### PR TITLE
Fixed -d error

### DIFF
--- a/utxodump.py
+++ b/utxodump.py
@@ -157,7 +157,7 @@ def main():
     args = parser.parse_args()
 
     if args.database:
-        is_blocks = 'blocks/index' in args.dadatabase
+        is_blocks = 'blocks/index' in args.database
         conn = leveldb.LevelDB(args.database)
     else:
         is_blocks = args.blocks


### PR DESCRIPTION
The variable args.database was written by mistake like args.dadatabase, this causes an error by calling the program on a directory different from the default one (ie using -d or --database).